### PR TITLE
Dependency fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Simon Bernier St-Pierre <sbernierstpierre@gmail.com>"]
 
 [dependencies]
-futures = { git = "https://github.com/alexcrichton/futures-rs" }
-futures-cpupool = { git = "https://github.com/alexcrichton/futures-rs" }
+futures = "0.1.1"
+futures-cpupool = "0.1.1"
 lazy_static = "0.2"
 tokio-core = { git = "https://github.com/tokio-rs/tokio-core.git" }
 log = "0.3"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
 
     // connect using the built-in resolver.
     let conn = tcp_connect("rust-lang.org:80", &lp.handle()).and_then(|sock| {
-        println!("conncted to {}", sock.peer_addr().unwrap());
+        println!("connected to {}", sock.peer_addr().unwrap());
         Ok(())
     });
 


### PR DESCRIPTION
Fixed dependency. Current "master" doesn't compile as far as I understand, because tokio-core depends on futures v0.1.1 instead of a master.

Just for the record, error is:

```
src/resolver.rs:36:5: 44:6 error: method `resolve` has an incompatible type for trait:
 expected trait `futures::Future`,
    found a different trait `futures::Future` [E0053]
src/resolver.rs:36     fn resolve(&self, host: &str) -> IoFuture<Vec<IpAddr>> {
                       ^
src/resolver.rs:36:5: 44:6 help: run `rustc --explain E0053` to see a detailed explanation
error: aborting due to previous error
error: Could not compile `tokio-dns`.
```
