### PR TITLE
resolve_hostname function to resolve host:port pairs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,5 +44,5 @@ where
 }
 
 pub use endpoint::{Endpoint, ToEndpoint};
-pub use net::{resolve, TcpListener, TcpStream, UdpSocket};
+pub use net::{resolve, resolve_hostname, TcpListener, TcpStream, UdpSocket};
 pub use resolver::{CpuPoolResolver, Resolver};

--- a/src/net.rs
+++ b/src/net.rs
@@ -14,11 +14,16 @@ lazy_static! {
 }
 
 /// Resolve a host using the default resolver.
-pub fn resolve<'a, T>(host: &str) -> IoFuture<Vec<IpAddr>>
-where
-    T: ToEndpoint<'a>,
+pub fn resolve(host: &str) -> IoFuture<Vec<IpAddr>>
 {
     POOL.resolve(host)
+}
+
+/// Resolves hostname (host:port) using the default resolver
+/// into a vector of socket addresses.
+pub fn resolve_hostname(host: &str) -> IoFuture<Vec<SocketAddr>>
+{
+    resolve_endpoint(host, POOL.clone())
 }
 
 /// Shim for tokio::net::TcpStream


### PR DESCRIPTION
I needed to resolve udp hostname (ip:port) manually, so i could send udp packets to hostnames specified from command line.

Is it good enough to merge in?