### PR TITLE
Update crate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["tokio", "async", "dns"]
 license = "Apache-2.0/MIT"
 exclude = [".travis.yml"]
+edition = "2018"
 
 [lib]
 name = "tokio_dns"

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -117,7 +117,7 @@ impl<'a> ToEndpoint<'a> for &'a str {
         match self.rfind(":") {
             Some(idx) => {
                 let host = &self[..idx];
-                let port = try!(parse_port(&self[idx + 1..]));
+                let port = parse_port(&self[idx + 1..])?;
                 Ok(Endpoint::Host(host, port))
             }
             None => Err(io::Error::new(io::ErrorKind::Other, "invalid endpoint")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,19 +34,19 @@ use std::io;
 use futures::future::Future;
 
 /// An alias for the futures produced by this library.
-pub type IoFuture<T> = Box<Future<Item = T, Error = io::Error> + Send>;
+pub type IoFuture<T> = Box<dyn Future<Item = T, Error = io::Error> + Send>;
 
-fn boxed<F>(fut: F) -> Box<Future<Item = F::Item, Error = F::Error> + Send>
+fn boxed<F>(fut: F) -> Box<dyn Future<Item = F::Item, Error = F::Error> + Send>
 where
     F: Future + Send + 'static,
 {
     Box::new(fut)
 }
 
-pub use endpoint::{Endpoint, ToEndpoint};
+pub use crate::endpoint::{Endpoint, ToEndpoint};
 #[allow(deprecated)]
-pub use net::{
+pub use crate::net::{
     resolve, resolve_ip_addr, resolve_ip_addr_with, resolve_sock_addr, resolve_sock_addr_with,
     TcpListener, TcpStream, UdpSocket,
 };
-pub use resolver::{CpuPoolResolver, Resolver};
+pub use crate::resolver::{CpuPoolResolver, Resolver};

--- a/src/net.rs
+++ b/src/net.rs
@@ -5,9 +5,9 @@ use futures::stream::Stream;
 use futures::{self, Future, IntoFuture};
 use tokio::net;
 
-use endpoint::{Endpoint, ToEndpoint};
-use resolver::{CpuPoolResolver, Resolver};
-use {boxed, IoFuture};
+use crate::endpoint::{Endpoint, ToEndpoint};
+use crate::resolver::{CpuPoolResolver, Resolver};
+use crate::{boxed, IoFuture};
 
 lazy_static! {
     static ref POOL: CpuPoolResolver = CpuPoolResolver::new(5);
@@ -188,7 +188,7 @@ where
     ));
     boxed(
         futures::stream::iter_ok(addrs.into_iter())
-            .fold::<_, _, Box<Future<Item = _, Error = io::Error> + Send>>(
+            .fold::<_, _, Box<dyn Future<Item = _, Error = io::Error> + Send>>(
                 result,
                 move |prev, addr| {
                     match prev {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,7 +3,7 @@ use std::str;
 
 use futures_cpupool::CpuPool;
 
-use {boxed, IoFuture};
+use crate::{boxed, IoFuture};
 
 /// The Resolver trait represents an object capable of
 /// resolving host names into IP addresses.


### PR DESCRIPTION
Update crate to Rust 2018 using 'cargo fix --edition'