### PR TITLE
Bump to tokio-0.2.0-alpha.3 and fix errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ path = "src/lib.rs"
 [dependencies]
 futures-preview = "0.3.0-alpha.18"
 lazy_static = "1.0"
-tokio = "0.2.0-alpha.2"
+tokio = "0.2.0-alpha.3"

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -114,7 +114,7 @@ impl<'a> ToEndpoint<'a> for &'a str {
             u16::from_str(port).map_err(|_| io::Error::new(io::ErrorKind::Other, "invalid port"))
         }
 
-        match self.rfind(":") {
+        match self.rfind(':') {
             Some(idx) => {
                 let host = &self[..idx];
                 let port = parse_port(&self[idx + 1..])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,6 @@ mod endpoint;
 mod net;
 mod resolver;
 
-use std::{io, pin::Pin};
-
-use futures::prelude::*;
-
 pub use crate::endpoint::{Endpoint, ToEndpoint};
 #[allow(deprecated)]
 pub use crate::net::{

--- a/src/net.rs
+++ b/src/net.rs
@@ -88,9 +88,10 @@ impl TcpStream {
         T: ToEndpoint<'a>,
         R: Resolver,
     {
-        try_until_ok(resolve_endpoint(ep, resolver).await?, move |addr| {
-            net::TcpStream::connect(&addr)
-        })
+        try_until_ok(
+            resolve_endpoint(ep, resolver).await?,
+            net::TcpStream::connect,
+        )
         .await
     }
 }
@@ -113,9 +114,10 @@ impl TcpListener {
         T: ToEndpoint<'a>,
         R: Resolver,
     {
-        try_until_ok(resolve_endpoint(ep, resolver).await?, move |addr| {
-            future::ready(net::TcpListener::bind(&addr))
-        })
+        try_until_ok(
+            resolve_endpoint(ep, resolver).await?,
+            net::TcpListener::bind,
+        )
         .await
     }
 }
@@ -138,10 +140,7 @@ impl UdpSocket {
         T: ToEndpoint<'a>,
         R: Resolver,
     {
-        try_until_ok(resolve_endpoint(ep, resolver).await?, move |addr| {
-            future::ready(net::UdpSocket::bind(&addr))
-        })
-        .await
+        try_until_ok(resolve_endpoint(ep, resolver).await?, net::UdpSocket::bind).await
     }
 }
 


### PR DESCRIPTION
The `*::bind` functions is now async.